### PR TITLE
Add install_requires to setup.py; add requirements.txt for pip instal…

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ it, you can do so:
 # Usage
 Simply start Pext with Python 3. If you have installed Pext using the above
 command, simply start `pext`. Otherwise, go to the root directory and run
+`pip3 install -r requirements.txt`
 `python3 pext`.
 
 To actually use Pext, you will first have to install one or more modules. Check

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+--index-url https://pypi.python.org/simple/
+
+-e .

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,9 @@ with open(os.path.join('pext', 'VERSION')) as version_file:
 setup(
     name='Pext',
     version=version,
+    install_requires=[
+        'pyqt5'
+    ],
     description='Python-based extendable tool',
     long_description='A Python-based application that uses modules for extendability',
     url='https://github.com/Pext/Pext',


### PR DESCRIPTION
- Adds install_dependencies to setup.py
- Update README for installing dependencies via Pip

This addresses Issue #5.

This doesn't address the missing dependencies in the core modules you've created. Short list:
- pext_module_pass
  *\* pexpect
  *\* pyinotify
- pext_module_emoji
  *\* emoji

Not sure how to address that. A couple of options:
1. Give the core modules installers and let people install them via Pip, then update the ModuleManager to search the global namespace for Pext Modules.
2. update the Module installer to actually install the modules as Python libraries. This would probably fail if the user is not running Pext in a virtualenv or as root(!)
3. Add the dependencies of the core modules to the dependency list of Pext itself (kind of ugly)
4. ???
