### PR TITLE
Fix installation requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     name='Pext',
     version=version,
     install_requires=[
-        'pygit2',
+        'dulwich',
         'pyqt5'
     ],
     description='Python-based extendable tool',


### PR DESCRIPTION
Since we've switched from pygit2 to dulwich, the setup script should install the right package. Blocks #31.