### PR TITLE
Remove pyqt5 from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,7 @@ setup(
     name='Pext',
     version=version,
     install_requires=[
-        'dulwich',
-        'pyqt5'
+        'dulwich'
     ],
     description='Python-based extendable tool',
     long_description='A Python-based application that uses modules for extendability',


### PR DESCRIPTION
`pyqt5` is not detected correctly when installed locally via `setup.py install` and fails with an error:
`DistributionNotFound: The 'pyqt5' distribution was not found and is required by Pext`

This made packaging for Arch GNU/Linux in AUR impossible