### PR TITLE
Spelling: Unsupported format, not %2

### DIFF
--- a/pext/qml/InstallFromRepositoryDialog.qml
+++ b/pext/qml/InstallFromRepositoryDialog.qml
@@ -56,7 +56,7 @@ Dialog {
         }
 
         Label {
-            text: qsTr("Repository format not supported (expected version %1, got version %2).").arg(expectedVersion).arg(currentRepoVersion)
+            text: qsTr("Unsupported repository format (expected version %1, not %2).").arg(expectedVersion).arg(currentRepoVersion)
             font.bold: true
             visible: expectedVersion != currentRepoVersion
         }


### PR DESCRIPTION
One redundancy cleared and one superfluous word omitted.