### PR TITLE
Format README and INSTALL with linter

### DIFF
--- a/INSTALL_FROM_SOURCE.md
+++ b/INSTALL_FROM_SOURCE.md
@@ -1,83 +1,113 @@
 # Installing Pext from source
+
 All of these steps assume you have already downloaded Pext and are currently in the root directory of the download.
 
 ## GNU/Linux
+
 ### Preparation
+
 The following dependencies need to be installed:
 
 #### Arch
 
-    sudo pacman -S libnotify python-pip python-pyqt5 qt5-quickcontrols
+```sh
+sudo pacman -S libnotify python-pip python-pyqt5 qt5-quickcontrols
+```
 
 You will also need python-dulwich from the AUR.
 
 #### Debian
 
-    sudo apt-get install libnotify-bin python3-pip python3-dulwich python3-pyqt5.qtquick qml-module-qtquick-controls
+```sh
+sudo apt-get install libnotify-bin python3-pip python3-dulwich python3-pyqt5.qtquick qml-module-qtquick-controls
+```
 
-You may also need to install libssl1.0-dev due to what seems like a Debian packaging issue. See https://stackoverflow.com/a/42297296 for more info.
+You may also need to install libssl1.0-dev due to what seems like a Debian packaging issue. See <https://stackoverflow.com/a/42297296> for more info.
 
 #### Fedora
 
-    sudo dnf install libnotify python3-dulwich python3-pip python3-qt5 qt5-qtquickcontrols
+```sh
+sudo dnf install libnotify python3-dulwich python3-pip python3-qt5 qt5-qtquickcontrols
+```
 
 #### Nix (any system, not just NixOS)
 
-    nix-shell -p libnotify python3Packages.pip python3Packages.dulwich python3Packages.pyqt5 qt5.qtquickcontrols
+```sh
+nix-shell -p libnotify python3Packages.pip python3Packages.dulwich python3Packages.pyqt5 qt5.qtquickcontrols
+```
 
 #### openSUSE
 
-    sudo zypper install libnotify-tools python3-dulwich python3-pip python3-qt5
+```sh
+sudo zypper install libnotify-tools python3-dulwich python3-pip python3-qt5
+```
 
 ### Starting Pext
+
 After installing the dependencies, Pext can be ran by running one of the following commands in the place where you saved Pext to:
+
 - ``python3 pext`` to start Pext itself
 - ``python3 pext_dev`` to start the Pext tools for module and theme development
 
 If desired, it can also be installed using the following command:
 
-    $ pip3 install . --user --upgrade --no-deps
+```sh
+pip3 install . --user --upgrade --no-deps
+```
 
 After doing this, you can start Pext like any application, or use ``pext`` and ``pext_dev`` on the command line.
 
 ## macOS
+
 ### Preparation
+
 The following commands need to be run. If you do not have the brew command, follow the installation instructions on [Homebrew's website](https://brew.sh/).
 
-Before running the Install Certificates command, which is only necessary to be able to retrieve the online module list, please read https://bugs.python.org/msg283984.
+Before running the Install Certificates command, which is only necessary to be able to retrieve the online module list, please read <https://bugs.python.org/msg283984>.
 
-    brew install libnotify python3 qt5
-    pip3 install certifi dulwich pyqt5 urllib3
-    /Applications/Python\ 3.6/Install\ Certificates.command
+```sh
+brew install libnotify python3 qt5
+pip3 install certifi dulwich pyqt5 urllib3
+/Applications/Python\ 3.6/Install\ Certificates.command
+```
 
 ### Starting Pext
+
 After installing the dependencies, Pext can be ran by running one of the following commands in a terminal window in the place where you saved Pext to:
+
 - ``python3 pext`` to start Pext itself
 - ``python3 pext_dev`` to start the Pext tools for module and theme development
 
 If desired, it can also be installed using the following command:
 
-    $ pip3 install . --user --upgrade --no-deps
+```sh
+pip3 install . --user --upgrade --no-deps
+```
 
 After doing this (and adding "$HOME/Library/Python/3.6/bin" to your $PATH), you can start Pext like any application, or use ``pext`` and ``pext_dev`` on the command line.
 
 Optionally, a .app file can be generated using the following commands:
 
-    ./build_mac_app.sh
+```sh
+./build_mac_app.sh
+```
 
 The .app file appears in the dist directory and can be dragged to "My Applications".
 
 ## Windows (experimental)
+
 ### Preparation
-Assuming you have no previous python installation, either 
+
+Assuming you have no previous python installation, either
 
 - Use a package manager like [Chocolatey](http://chocolatey.org/) to install Python 3
-- Install Python 3.6 manually from https://www.python.org/downloads/windows/
+- Install Python 3.6 manually from <https://www.python.org/downloads/windows/>
 
 Then, assuming python and pip are installed, run `pip install dulwich PyQt5` in a command window.
 
 ### Starting Pext
+
 Pext can be ran by ran from a command window by running one of the following commands in the place where you saved Pext to (type ``cd place_you_saved_pext`` to go there):
+
 - ``python pext`` to start Pext itself
 - ``python pext_dev`` to start the Pext tools for module and theme development
-

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Code Health](https://landscape.io/github/Pext/Pext/master/landscape.svg?style=flat)](https://landscape.io/github/Pext/Pext/master)
 
 ## Contents
+
 - [Community](#community)
 - [Introduction](#introduction)
 - [How it works](#how-it-works)
@@ -23,6 +24,7 @@
 - [License](#license)
 
 ## Community
+
 If you need support or just want to chat with our community, we have the following options:
 
 - IRC: #pext on OFTC ([webchat](https://webchat.oftc.net/?randomnick=1&channels=pext&prompt=1))
@@ -34,6 +36,7 @@ All these channels are linked to each other, so there is no need to worry about 
 We can also be reached on Twitter: [@PextTool](https://twitter.com/PextTool)
 
 ## Introduction
+
 Pext stands for **P**ython-based **ex**tendable **t**ool. It is built using Python 3 and Qt5 QML and has its behaviour decided by modules. Pext provides a simple window with a search bar, allowing modules to define what data is shown and how it is manipulated.
 
 For example, say you want to use Pext as a password manager. You load in the pass module, and it will show you a list of your passwords which you can filter with the search bar. When you select a password in the list, it will copy the password to your clipboard and Pext will hide itself, waiting for you to ask for it again.
@@ -42,52 +45,65 @@ Depending on the module you choose, what entries are shown and what happens when
 
 Several modules are available for effortless install right within Pext.
 
-![Pext running the radiobrowser module with info panel](/screenshots/pext_radiobrowser_infopanel.png)  
-![Pext running the openweathermap module with context menu](/screenshots/pext_openweathermap_contextmenu.png)  
+![Pext running the radiobrowser module with info panel](/screenshots/pext_radiobrowser_infopanel.png)
+![Pext running the openweathermap module with context menu](/screenshots/pext_openweathermap_contextmenu.png)
 ![Pext running the emoji module](/screenshots/pext_emoji.png)
 
 ## How it works
+
 Pext is designed to quickly pop up and get out of your way as soon as you're done with something. It is recommended to bind Pext to some global hotkey, or possibly run multiple instances of it with different profiles under multiple hotkeys. Example Pext workflows look as follows:
 
 ![Pext workflow graph](/workflow_graph.png)
 
 Simply put:
+
 - Open (Pext)
 - Search (for something)
 - Select (with Enter)
 - Hide (automatically)
 
 ## Installation
+
 **Note: If you run into any issues, please check out the troubleshooting section near the end of this document before reporting a bug.**
 
 ### GNU/Linux
+
 #### Arch
+
 Pext is available as [pext](https://aur.archlinux.org/packages/pext/) and [pext-git](https://aur.archlinux.org/packages/pext-git/). These packages are maintained by [Ivan Semkin](https://github.com/vanyasem).
 
 #### Other distros
+
 We recommend the AppImages under GitHub releases, but you can also install from PyPI.
 
 For the stable version (PyPI):
 
-    $ pip3 install pext --user
+```sh
+pip3 install pext --user
+```
 
 For the git version (PyPI):
 
-    $ pip3 install git+https://github.com/Pext/Pext.git --user
+```sh
+pip3 install git+https://github.com/Pext/Pext.git --user
+```
 
 On some systems, you may need to use pip instead of pip3.
 
 Alternatively, you can [install Pext from source](INSTALL_FROM_SOURCE.md)
 
 ### macOS
+
 A macOS .dmg file is available [in the releases section on GitHub](https://github.com/Pext/Pext/releases). This is still experimental, please report any issues.
 
 Alternatively, see [Installing Pext from source](INSTALL_FROM_SOURCE.md)
 
 ### Windows (experimental)
+
 See [Installing Pext from source](INSTALL_FROM_SOURCE.md)
 
 ## Usage
+
 To actually use Pext, you will first have to install one or more modules. Check out the Pext organisation on [GitHub](https://github.com/Pext) or use `Module` -> `Install module` -> `From online module list` in the application for a list of modules.
 
 After installating at least one module, you can load it from the `Module` -> `Load module` menu. After that, experiment! Each module is different.
@@ -95,7 +111,9 @@ After installating at least one module, you can load it from the `Module` -> `Lo
 For command line options, use `--help`.
 
 ## Hotkeys
+
 ### Entry management
+
 - Escape: Go one level up
 - Tab: Tab-complete the current input
 - Enter / Left mouse button: Select entry or run command
@@ -107,6 +125,7 @@ For command line options, use `--help`.
 - Ctrl+B / Page up: Go one page up
 
 ### Tab management
+
 - Ctrl+T: Open new tab
 - Ctrl+W: Close current tab
 - Ctrl+Tab: Switch to next tab
@@ -115,29 +134,37 @@ For command line options, use `--help`.
 - F5: Reload tab, including code changes to the module
 
 ### Session management
+
 - Ctrl+Q: Quit and save the currently loaded modules and settings to the profile
 - Ctrl+Shift+Q: Quit without saving to the profile
 
 ## Troubleshooting
+
 ### GNU/Linux
+
 #### Installing module dependencies fails
+
 Your distribution may ship with an outdated version of pip. Run ``pip install --upgrade pip`` (possibly as root) in a terminal.
 
 #### Pext's window is completely white
+
 The proprietary NVIDIA driver is known to cause this issue on at least Ubuntu. You can work around this by running ``sudo apt-get install python3-opengl``.
 
-Pext user report: https://github.com/Pext/Pext/issues/11  
-Ubuntu bug: https://bugs.launchpad.net/ubuntu/+source/python-qt4/+bug/941826
+Pext user report: <https://github.com/Pext/Pext/issues/11>
+Ubuntu bug: <https://bugs.launchpad.net/ubuntu/+source/python-qt4/+bug/941826>
 
 ### macOS
+
 #### I cannot brew/pip install anymore
+
 The Homebrew team completely broke pip's --target flag, which Pext depends on. To work around this, Pext automatically creates a ``~/.pydistutils.cfg`` file which resets the broken Homebrew pip defaults and deletes this file after its done installing module dependencies.
 
 As a side effect, this means that using brew install or pip install while Pext is installing module dependencies may fail. If you cannot use brew install or pip install at all anymore after Pext crashed, please delete ``~/.pydistutils.cfg`` if it exists.
 
-The Homebrew team refuses to fix this issue: https://github.com/Homebrew/brew/issues/837
+The Homebrew team refuses to fix this issue: <https://github.com/Homebrew/brew/issues/837>
 
 ### Windows
+
 #### The python or pip commands do not work/The PATH variable is wrong
 
 In the installer, make sure that 'Include Python in PATH' or similar is checked. Then after the installation, start a new command prompt and type `python -V` or `pip3` to check if it was properly installed. If the version number and the help message are returned respectively, you are good to go further. If not, in case you already had `cmd.exe` open, restart it or execute `refreshenv` to reload environment variables.
@@ -151,12 +178,14 @@ GUI:
 cmd.exe:
 
 - Run `path` or `echo %PATH%` to check if the directory (`C:\Python36` and `C:\Python36\Scripts`) is included
-- The path can then be set with `setx` but because the possibility for truncation and the merging of users and system path, the gui method is to be preferred. (more details: https://stackoverflow.com/questions/9546324/adding-directory-to-path-environment-variable-in-windows)
+- The path can then be set with `setx` but because the possibility for truncation and the merging of users and system path, the gui method is to be preferred. (more details: <https://stackoverflow.com/questions/9546324/adding-directory-to-path-environment-variable-in-windows>)
 
 ## License
+
 Pext is licensed under the [GNU GPLv3+](LICENSE), with exception of artwork and documentation, which are licensed under the [Creative Commons Attribution Share-Alike 4.0 license](LICENSE-CCBYSA).
 
 Under artwork and documentation fall:
+
 - All files in the following directories:
   - docs/
   - pext/images/
@@ -165,4 +194,4 @@ Under artwork and documentation fall:
 - All Markdown files in the root directory.
 - logo.png
 
-When attributing the logo (which was donated by [vaeringjar](https://notabug.org/vaeringjar)), it should be attributed as Lilly the leoger by White Paper Fox. Alternatively, it may be referred to as the Pext logo. Please link to Pext with https://github.com/Pext/Pext or https://pext.hackerchick.me/ and to White Paper Fox with http://www.whitepaperfox.com/ where possible.
+When attributing the logo (which was donated by [vaeringjar](https://notabug.org/vaeringjar)), it should be attributed as Lilly the leoger by White Paper Fox. Alternatively, it may be referred to as the Pext logo. Please link to Pext with <https://github.com/Pext/Pext> or <https://pext.hackerchick.me/> and to White Paper Fox with <http://www.whitepaperfox.com/> where possible.


### PR DESCRIPTION
The markdown files were linted in accordance with the [markdownlint](https://github.com/DavidAnson/markdownlint/blob/v0.8.1/doc/Rules.md) linter with Visual Studio Code. This pull request adds space to headers, adds code blocks, and surrounds bare URLs with greater/less than signs. 