### PR TITLE
Spelling: Updates → new versions.

### DIFF
--- a/pext/qml/main.qml
+++ b/pext/qml/main.qml
@@ -686,7 +686,7 @@ ApplicationWindow {
 
                 MenuItem {
                     objectName: "menuEnableObjectUpdateCheck"
-                    text: qsTr("Install new modules and themes automatically")
+                    text: qsTr("Download and install new modules and themes automatically")
                     checkable: true
                 }
             }

--- a/pext/qml/main.qml
+++ b/pext/qml/main.qml
@@ -675,18 +675,18 @@ ApplicationWindow {
             }
 
             Menu {
-                title: qsTr("Automatic updates")
+                title: qsTr("New versions")
 
                 MenuItem {
                     objectName: "menuEnableUpdateCheck"
-                    text: qsTr("Automatically check for Pext updates")
+                    text: qsTr("Check for new Pext versions automatically")
                     checkable: true
                     visible: internalUpdaterEnabled
                 }
 
                 MenuItem {
                     objectName: "menuEnableObjectUpdateCheck"
-                    text: qsTr("Automatically update modules and themes")
+                    text: qsTr("Install new modules and themes automatically")
                     checkable: true
                 }
             }
@@ -714,7 +714,7 @@ ApplicationWindow {
 
             MenuItem {
                 objectName: "menuCheckForUpdates"
-                text: qsTr("Check for updates")
+                text: qsTr("Check for new versions")
             }
 
             MenuItem {


### PR DESCRIPTION
The difference between updating and upgrading is better suited to just going with "new versions"
Edit: It would appear that "menuEnableUpdateCheck" and "menuEnableObjectUpdateCheck"
are the same for different things, and as such should read the same, but I don't know.