### PR TITLE
Do the check for Debian a bit more carefully

### DIFF
--- a/pext/__main__.py
+++ b/pext/__main__.py
@@ -994,8 +994,9 @@ class ModuleManager():
 
         # FIXME: Cheap hack to work around Debian's faultily-patched pip
         # We try to prevent false positives by checking for (mini)conda or a venv
-        if ("conda" not in sys.version and os.path.isfile('/etc/debian_version') and
-           not hasattr(sys, 'real_prefix') and not (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)):
+        if ("conda" not in sys.version and os.path.isfile('/etc/issue.net') and
+            'Debian' in open('/etc/issue.net', 'r').read() and 
+            not hasattr(sys, 'real_prefix') and not (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)):
             pip_command += ['--system']
 
         pip_command += ['--upgrade',


### PR DESCRIPTION
Mint and other Debian derivates also have `/etc/debian_version`.