### PR TITLE
Fix #175

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: required
 language: generic
+dist: xenial
 
 env:
   - PEXT_BUILD_PORTABLE=0

--- a/travis/bootstrap-container.sh
+++ b/travis/bootstrap-container.sh
@@ -6,8 +6,8 @@ sudo apt-get update
 sudo apt-get install -y python3.6
 
 # install proper cross-distro libcurl
-sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/TheAssassin:/AppImageLibraries/xUbuntu_14.04/ /' > /etc/apt/sources.list.d/curl-httponly.list"
-wget https://download.opensuse.org/repositories/home:/TheAssassin:/AppImageLibraries/xUbuntu_14.04/Release.key -O- | sudo apt-key add -
+sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/TheAssassin:/AppImageLibraries/xUbuntu_16.04/ /' > /etc/apt/sources.list.d/curl-httponly.list"
+wget https://download.opensuse.org/repositories/home:/TheAssassin:/AppImageLibraries/xUbuntu_16.04/Release.key -O- | sudo apt-key add -
 sudo apt-get update
 
 sudo apt-get install -y curl libcurl4-gnutls-dev libcurl3-gnutls libcurl3


### PR DESCRIPTION
I already explained that apparently OBS generates repo keys so they expire when the distro goes EOL. All I did was to change the `14.04` part to `16.04` and ensure we're building on `xenial` by updating `.travis.yml`.

Fixes #175.