### PR TITLE
Correct package gui entrypoint

### DIFF
--- a/pext/__main__.py
+++ b/pext/__main__.py
@@ -3313,8 +3313,8 @@ def main(ui_type: UIType) -> None:
     main_loop.run()
 
 
-def run_qt5():
-    """Entrypoint for starting with Qt5 UI"""
+def run_qt5() -> None:
+    """Entrypoint for starting with Qt5 UI."""
     main(UIType.Qt5)
 
 

--- a/pext/__main__.py
+++ b/pext/__main__.py
@@ -3313,5 +3313,10 @@ def main(ui_type: UIType) -> None:
     main_loop.run()
 
 
+def run_qt5():
+    """Entrypoint for starting with Qt5 UI"""
+    main(UIType.Qt5)
+
+
 if __name__ == "__main__":
     main(UIType.Qt5)

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
     zip_safe=False,
     entry_points={
         'gui_scripts': [
-            'pext=pext.__main__:main'
+            'pext=pext.__main__:run_qt5'
         ],
         'console_scripts': [
             'pext_dev=pext_dev.__main__:main'


### PR DESCRIPTION
This correction fix inability start pext gui
```
Traceback (most recent call last):
  File "/usr/bin/pext", line 33, in <module>
    sys.exit(load_entry_point('Pext==0.32', 'gui_scripts', 'pext')())
TypeError: main() missing 1 required positional argument: 'ui_type'
```