### PR TITLE
Separate Installation into its own section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 - [Introduction](#introduction)
 - [How it works](#how-it-works)
-- [Installation](https://pext.readthedocs.io/en/latest/installation.html)
+- [Installation](#installation)
 - [Usage](#usage)
 - [Hotkeys](#hotkeys)
 - [Community](#community)
@@ -49,6 +49,10 @@ Simply put:
 - Search (for something)
 - Select (with Enter)
 - Hide (automatically)
+
+## Installation
+
+Check the install instructions at [Read the Docs](https://pext.readthedocs.io/en/latest/installation.html).
 
 ## Usage
 


### PR DESCRIPTION
The current installation link looks like a section header, so people are less likely to click it.