### PR TITLE
Replace pep257 by pydocstyle

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,22 +80,22 @@ jobs:
 #          path: |
 #            Pext*.zip
 #            Pext*.dmg
-
-  upload:
-    name: Create release and upload artifacts
-    needs:
-      - linux
-      - osx
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-      - name: Inspect directory after downloading artifacts
-        run: ls -alFR
-      - name: Create release and upload artifacts
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-            wget -q https://github.com/TheAssassin/pyuploadtool/releases/download/continuous/pyuploadtool-x86_64.AppImage
-            chmod +x pyuploadtool-x86_64.AppImage
-            ./pyuploadtool-x86_64.AppImage $(find . -iname "Pext*.*") $(find . -iname "VERSION")
+#
+#  upload:
+#    name: Create release and upload artifacts
+#    needs:
+#      - linux
+#      - osx
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Download artifacts
+#        uses: actions/download-artifact@v3
+#      - name: Inspect directory after downloading artifacts
+#        run: ls -alFR
+#      - name: Create release and upload artifacts
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: |
+#            wget -q https://github.com/TheAssassin/pyuploadtool/releases/download/continuous/pyuploadtool-x86_64.AppImage
+#            chmod +x pyuploadtool-x86_64.AppImage
+#            ./pyuploadtool-x86_64.AppImage $(find . -iname "Pext*.*") $(find . -iname "VERSION")

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         OPERATIVE_SYSTEM: [ubuntu-18.04]
         # Python versions: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         # Python 3.6 has problems importing the requirement pyqt5==5.15.7.
-        PYTHON_VERSION: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        PYTHON_VERSION: ["3.11"]
       fail-fast: false
     name: "${{ matrix.OPERATIVE_SYSTEM }} Python-${{ matrix.PYTHON_VERSION }} Portable-${{ matrix.PEXT_BUILD_PORTABLE }}"
     runs-on: ${{ matrix.OPERATIVE_SYSTEM }}
@@ -54,9 +54,9 @@ jobs:
         PEXT_BUILD_PORTABLE: [0]
         # Operative systems: [macos-10.15, macos-11, macos-12]
         OPERATIVE_SYSTEM: [macos-latest]
-        # Python versions: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        # Python versions: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         # Python 3.6 has problems importing the requirement pyqt5==5.15.7.
-        PYTHON_VERSION: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        PYTHON_VERSION: ["3.11"]
       fail-fast: false
     name: "${{ matrix.OPERATIVE_SYSTEM }} Python-${{ matrix.PYTHON_VERSION }} Portable-${{ matrix.PEXT_BUILD_PORTABLE }}"
     runs-on: ${{ matrix.OPERATIVE_SYSTEM }}
@@ -80,21 +80,21 @@ jobs:
             Pext*.zip
             Pext*.dmg
 
-#  upload:
-#    name: Create release and upload artifacts
-#    needs:
-#      - linux
-#      - osx
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Download artifacts
-#        uses: actions/download-artifact@v3
-#      - name: Inspect directory after downloading artifacts
-#        run: ls -alFR
-#      - name: Create release and upload artifacts
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: |
-#            wget -q https://github.com/TheAssassin/pyuploadtool/releases/download/continuous/pyuploadtool-x86_64.AppImage
-#            chmod +x pyuploadtool-x86_64.AppImage
-#            ./pyuploadtool-x86_64.AppImage $(find . -iname "Pext*.*") $(find . -iname "VERSION")
+  upload:
+    name: Create release and upload artifacts
+    needs:
+      - linux
+      - osx
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+      - name: Inspect directory after downloading artifacts
+        run: ls -alFR
+      - name: Create release and upload artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+            wget -q https://github.com/TheAssassin/pyuploadtool/releases/download/continuous/pyuploadtool-x86_64.AppImage
+            chmod +x pyuploadtool-x86_64.AppImage
+            ./pyuploadtool-x86_64.AppImage $(find . -iname "Pext*.*") $(find . -iname "VERSION")

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,8 @@ jobs:
         # The Ubuntu version 22.04 has problems with Linux script to deploy plugin conda.
         OPERATIVE_SYSTEM: [ubuntu-18.04]
         # Python versions: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
-        # The Python versions 3.6 has problems with QT.
-        PYTHON_VERSION: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        # Python 3.6 has problems importing the requirement pyqt5==5.15.7.
+        PYTHON_VERSION: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
     name: "${{ matrix.OPERATIVE_SYSTEM }} Python-${{ matrix.PYTHON_VERSION }} Portable-${{ matrix.PEXT_BUILD_PORTABLE }}"
     runs-on: ${{ matrix.OPERATIVE_SYSTEM }}
@@ -46,40 +46,40 @@ jobs:
             build/Pext*.AppImage.zsync
             pext/VERSION
 
-#  osx:
-#    strategy:
-#      matrix:
-#        # Pext portable: [0, 1]
-#        # The portable version is not working in macOS.
-#        PEXT_BUILD_PORTABLE: [0]
-#        # Operative systems: [macos-10.15, macos-11, macos-12]
-#        OPERATIVE_SYSTEM: [macos-latest]
-#        # Python versions: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-#        # The Python versions 3.6 and 3.10 are not working correctly.
-#        PYTHON_VERSION: ["3.9"]
-#      fail-fast: false
-#    name: "${{ matrix.OPERATIVE_SYSTEM }} Python-${{ matrix.PYTHON_VERSION }} Portable-${{ matrix.PEXT_BUILD_PORTABLE }}"
-#    runs-on: ${{ matrix.OPERATIVE_SYSTEM }}
-#    env:
-#      PEXT_BUILD_PORTABLE: ${{ matrix.PEXT_BUILD_PORTABLE }}
-#    steps:
-#      - uses: actions/checkout@v3
-#        with:
-#          fetch-depth: 0
-#      - name: Set up
-#        uses: actions/setup-python@v4
-#        with:
-#          python-version: ${{ matrix.PYTHON_VERSION }}
-#      - name: Build
-#        run: bash -xve ci/build-macos.sh ${{ matrix.PYTHON_VERSION }}
-#      - name: Archive artifacts
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: ${{ matrix.OPERATIVE_SYSTEM }}_Python-${{ matrix.PYTHON_VERSION }}_Portable-${{ matrix.PEXT_BUILD_PORTABLE }}
-#          path: |
-#            Pext*.zip
-#            Pext*.dmg
-#
+  osx:
+    strategy:
+      matrix:
+        # Pext portable: [0, 1]
+        # The portable version is not working in macOS.
+        PEXT_BUILD_PORTABLE: [0]
+        # Operative systems: [macos-10.15, macos-11, macos-12]
+        OPERATIVE_SYSTEM: [macos-latest]
+        # Python versions: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        # Python 3.6 has problems importing the requirement pyqt5==5.15.7.
+        PYTHON_VERSION: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+      fail-fast: false
+    name: "${{ matrix.OPERATIVE_SYSTEM }} Python-${{ matrix.PYTHON_VERSION }} Portable-${{ matrix.PEXT_BUILD_PORTABLE }}"
+    runs-on: ${{ matrix.OPERATIVE_SYSTEM }}
+    env:
+      PEXT_BUILD_PORTABLE: ${{ matrix.PEXT_BUILD_PORTABLE }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.PYTHON_VERSION }}
+      - name: Build
+        run: bash -xve ci/build-macos.sh ${{ matrix.PYTHON_VERSION }}
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.OPERATIVE_SYSTEM }}_Python-${{ matrix.PYTHON_VERSION }}_Portable-${{ matrix.PEXT_BUILD_PORTABLE }}
+          path: |
+            Pext*.zip
+            Pext*.dmg
+
 #  upload:
 #    name: Create release and upload artifacts
 #    needs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,10 +19,10 @@ jobs:
         # Operative systems: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
         # The Ubuntu version 22.04 has problems with Linux script to deploy plugin conda.
         OPERATIVE_SYSTEM: [ubuntu-18.04]
-        # Python versions: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        # Python versions: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         # The Python versions 3.6 has problems with QT.
         # The Python versions 3.10 has problems with Tox Travis.
-        PYTHON_VERSION: ["3.9"]
+        PYTHON_VERSION: ["3.9", "3.10", "3.11"]
       fail-fast: false
     name: "${{ matrix.OPERATIVE_SYSTEM }} Python-${{ matrix.PYTHON_VERSION }} Portable-${{ matrix.PEXT_BUILD_PORTABLE }}"
     runs-on: ${{ matrix.OPERATIVE_SYSTEM }}
@@ -47,39 +47,39 @@ jobs:
             build/Pext*.AppImage.zsync
             pext/VERSION
 
-  osx:
-    strategy:
-      matrix:
-        # Pext portable: [0, 1]
-        # The portable version is not working in macOS.
-        PEXT_BUILD_PORTABLE: [0]
-        # Operative systems: [macos-10.15, macos-11, macos-12]
-        OPERATIVE_SYSTEM: [macos-latest]
-        # Python versions: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-        # The Python versions 3.6 and 3.10 are not working correctly.
-        PYTHON_VERSION: ["3.9"]
-      fail-fast: false
-    name: "${{ matrix.OPERATIVE_SYSTEM }} Python-${{ matrix.PYTHON_VERSION }} Portable-${{ matrix.PEXT_BUILD_PORTABLE }}"
-    runs-on: ${{ matrix.OPERATIVE_SYSTEM }}
-    env:
-      PEXT_BUILD_PORTABLE: ${{ matrix.PEXT_BUILD_PORTABLE }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Set up
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.PYTHON_VERSION }}
-      - name: Build
-        run: bash -xve ci/build-macos.sh ${{ matrix.PYTHON_VERSION }}
-      - name: Archive artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ matrix.OPERATIVE_SYSTEM }}_Python-${{ matrix.PYTHON_VERSION }}_Portable-${{ matrix.PEXT_BUILD_PORTABLE }}
-          path: |
-            Pext*.zip
-            Pext*.dmg
+#  osx:
+#    strategy:
+#      matrix:
+#        # Pext portable: [0, 1]
+#        # The portable version is not working in macOS.
+#        PEXT_BUILD_PORTABLE: [0]
+#        # Operative systems: [macos-10.15, macos-11, macos-12]
+#        OPERATIVE_SYSTEM: [macos-latest]
+#        # Python versions: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+#        # The Python versions 3.6 and 3.10 are not working correctly.
+#        PYTHON_VERSION: ["3.9"]
+#      fail-fast: false
+#    name: "${{ matrix.OPERATIVE_SYSTEM }} Python-${{ matrix.PYTHON_VERSION }} Portable-${{ matrix.PEXT_BUILD_PORTABLE }}"
+#    runs-on: ${{ matrix.OPERATIVE_SYSTEM }}
+#    env:
+#      PEXT_BUILD_PORTABLE: ${{ matrix.PEXT_BUILD_PORTABLE }}
+#    steps:
+#      - uses: actions/checkout@v3
+#        with:
+#          fetch-depth: 0
+#      - name: Set up
+#        uses: actions/setup-python@v4
+#        with:
+#          python-version: ${{ matrix.PYTHON_VERSION }}
+#      - name: Build
+#        run: bash -xve ci/build-macos.sh ${{ matrix.PYTHON_VERSION }}
+#      - name: Archive artifacts
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: ${{ matrix.OPERATIVE_SYSTEM }}_Python-${{ matrix.PYTHON_VERSION }}_Portable-${{ matrix.PEXT_BUILD_PORTABLE }}
+#          path: |
+#            Pext*.zip
+#            Pext*.dmg
 
   upload:
     name: Create release and upload artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,8 +21,7 @@ jobs:
         OPERATIVE_SYSTEM: [ubuntu-18.04]
         # Python versions: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         # The Python versions 3.6 has problems with QT.
-        # The Python versions 3.10 has problems with Tox Travis.
-        PYTHON_VERSION: ["3.9", "3.10", "3.11"]
+        PYTHON_VERSION: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
     name: "${{ matrix.OPERATIVE_SYSTEM }} Python-${{ matrix.PYTHON_VERSION }} Portable-${{ matrix.PEXT_BUILD_PORTABLE }}"
     runs-on: ${{ matrix.OPERATIVE_SYSTEM }}

--- a/pext/ui_qt5.py
+++ b/pext/ui_qt5.py
@@ -1557,7 +1557,7 @@ class HotkeyHandler():
             listener.start()
 
     def on_press(self, key) -> bool:
-        """Executed when a key is pressed."""
+        """Execute when a key is pressed."""
         if key is None:
             return True
 
@@ -1572,7 +1572,7 @@ class HotkeyHandler():
         return True
 
     def on_release(self, key) -> bool:
-        """Executed when a key is released."""
+        """Execute when a key is released."""
         try:
             self.modifiers.remove(key)
         except KeyError:

--- a/pext/ui_qt5.py
+++ b/pext/ui_qt5.py
@@ -1557,7 +1557,7 @@ class HotkeyHandler():
             listener.start()
 
     def on_press(self, key) -> bool:
-        """Execute when a key is pressed."""
+        """Track pressed keys and show window when all keys for the global hotkey are pressed."""
         if key is None:
             return True
 
@@ -1572,7 +1572,7 @@ class HotkeyHandler():
         return True
 
     def on_release(self, key) -> bool:
-        """Execute when a key is released."""
+        """Remove key from pressed keys list on release."""
         try:
             self.modifiers.remove(key)
         except KeyError:

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 # 3.5 is the lowest supported versions
-envlist = py35, py36, py37
+envlist = py35, py36, py37, py38, py39, py310
 
 [testenv]
 passenv = DISPLAY
@@ -13,12 +13,12 @@ commands =
     flake8 pext/ pext_dev/__main__.py test/
     mypy --ignore-missing-imports --follow-imports=skip pext/
     mypy --ignore-missing-imports --follow-imports=skip pext_dev/__main__.py
-    pep257 pext/ pext_dev/__main__.py
+    pydocstyle pext/ pext_dev/__main__.py
     python test/test.py
 deps =
     flake8
     mypy
-    pep257
+    pydocstyle
     types-setuptools
     types-requests
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,6 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 
-[tox]
-# 3.5 is the lowest supported versions
-envlist = py35, py36, py37, py38, py39, py310
-
 [testenv]
 passenv = DISPLAY
 commands =


### PR DESCRIPTION
Regarding the issue #457, the `pep257` was replaced by `pydocstyle`, and fixed some warnings/errors.