### PR TITLE
Use newer Ubuntu

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,12 +16,9 @@ jobs:
     strategy:
       matrix:
         PEXT_BUILD_PORTABLE: [0, 1]
-        # Operative systems: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
         # The Ubuntu version 22.04 has problems with Linux script to deploy plugin conda.
-        OPERATIVE_SYSTEM: [ubuntu-18.04]
-        # Python versions: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
-        # Python 3.6 has problems importing the requirement pyqt5==5.15.7.
-        PYTHON_VERSION: ["3.11"]
+        OPERATIVE_SYSTEM: [ubuntu-20.04]
+        PYTHON_VERSION: ["3.12"]
       fail-fast: false
     name: "${{ matrix.OPERATIVE_SYSTEM }} Python-${{ matrix.PYTHON_VERSION }} Portable-${{ matrix.PEXT_BUILD_PORTABLE }}"
     runs-on: ${{ matrix.OPERATIVE_SYSTEM }}
@@ -54,9 +51,7 @@ jobs:
         PEXT_BUILD_PORTABLE: [0]
         # Operative systems: [macos-10.15, macos-11, macos-12]
         OPERATIVE_SYSTEM: [macos-latest]
-        # Python versions: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
-        # Python 3.6 has problems importing the requirement pyqt5==5.15.7.
-        PYTHON_VERSION: ["3.11"]
+        PYTHON_VERSION: ["3.12"]
       fail-fast: false
     name: "${{ matrix.OPERATIVE_SYSTEM }} Python-${{ matrix.PYTHON_VERSION }} Portable-${{ matrix.PEXT_BUILD_PORTABLE }}"
     runs-on: ${{ matrix.OPERATIVE_SYSTEM }}


### PR DESCRIPTION
It's not really great for AppImage but 18.04 is not available anymore on GitHub and there is simply not enough time to keep Pext up-to-date with constant changes.